### PR TITLE
Gw 1910 accessibility audit headings

### DIFF
--- a/app/views/locations/upload_locations_csv.html.erb
+++ b/app/views/locations/upload_locations_csv.html.erb
@@ -50,9 +50,9 @@
                   </p>
                 <% end %>
 
-                <h1 class="govuk-fieldset__heading">
+                <h2 class="govuk-fieldset__heading">
                   <%= location.address %>, <%= location.postcode %>
-                </h1>
+                </h2>
               </div>
           </span>
         </h2>

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -19,8 +19,8 @@
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="sign-in-hint">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-            Permission level
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h2 class="govuk-fieldset__heading">Permission level</h2>
           </legend>
           <div class="govuk-radios" data-module="govuk-radios">
             <div class="govuk-radios__item">

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -4,7 +4,7 @@
               url: user_registration_path,
               method: :put do |f| %>
   <%= f.govuk_error_summary %>
-  <%= f.govuk_fieldset legend: { text: "Change your password", size: "xl", tag:"h1" } do %>
+  <%= f.govuk_fieldset legend: { text: "Change your password", size: "xl", tag: "h1" } do %>
     <%= f.govuk_password_field :current_password, label: { text: "Current password" } %>
     <%= f.govuk_password_field :password, label: { text: "Password" } %>
     <%= render "users/registrations/password_details" %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -4,7 +4,7 @@
               url: user_registration_path,
               method: :put do |f| %>
   <%= f.govuk_error_summary %>
-  <%= f.govuk_fieldset legend: { text: "Change your password", size: "xl" } do %>
+  <%= f.govuk_fieldset legend: { text: "Change your password", size: "xl", tag:"h1" } do %>
     <%= f.govuk_password_field :current_password, label: { text: "Current password" } %>
     <%= f.govuk_password_field :password, label: { text: "Password" } %>
     <%= render "users/registrations/password_details" %>


### PR DESCRIPTION
### What
#### Headings
Information, structure, and relationships conveyed through presentation could not be
programmatically determined or was not available in text.
On the 'Change your password' page, the legend 'Change your password' is visually
presented and introduces content as if a H1 page heading, yet it is not a heading.

### Why
On the 'Summary of upload' page, there are multiple pairs of duplicated H1 and H2 headings
(where, confusing the hierarchy, the H2 heading precedes the H1 heading, suggesting a
confusing headings hierarchy for the page).

Link to JIRA card (if applicable):
[GW-1910](https://technologyprogramme.atlassian.net/browse/GW-1910)


[GW-1910]: https://technologyprogramme.atlassian.net/browse/GW-1910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ