### PR TITLE
Removed "row=scope" from <td> added to <th>

### DIFF
--- a/app/views/super_admin/organisations/_locations.html.erb
+++ b/app/views/super_admin/organisations/_locations.html.erb
@@ -1,12 +1,12 @@
 <% if locations.any? %>
   <table class="govuk-table">
-    <thead class="govuk-table__head">
+    <thead class="govuk-table__head" scope="row">
     </thead>
     <tbody class="govuk-table__body">
       <% locations.each do |location| %>
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell" scope="row"><%= location.address %></td>
-          <td class="govuk-table__cell text-right" scope="row"><%= location.postcode %></td>
+          <td class="govuk-table__cell"><%= location.address %></td>
+          <td class="govuk-table__cell text-right"><%= location.postcode %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/super_admin/organisations/_team.html.erb
+++ b/app/views/super_admin/organisations/_team.html.erb
@@ -11,21 +11,21 @@
     <tbody class="govuk-table__body">
       <% team.each do |user| %>
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell" scope="row"><%= user.name %></td>
-          <td class="govuk-table__cell" scope="row">
+          <th class="govuk-table__cell" scope="row"><%= user.name %></th>
+          <td class="govuk-table__cell">
             <% if user.current_sign_in_at.present? %>
                 <%= user.current_sign_in_at.strftime("%-d %b %Y") %>
             <% end %>
             </td>
-          <td class="govuk-table__cell text-right" scope="row"><%= user.sign_in_count %></td>
-          <td class="govuk-table__cell text-right" scope="row"><%= user.email %></td>
-          <td class="govuk-table__cell text-right" scope="row">
+          <td class="govuk-table__cell text-right"><%= user.sign_in_count %></td>
+          <td class="govuk-table__cell text-right"><%= user.email %></td>
+          <td class="govuk-table__cell text-right">
             <%= link_to edit_membership_path(user.membership_for(@organisation), remove_team_member: true),
                         class: "govuk-button red-button" do %>
               Remove user <span class='govuk-visually-hidden'>- <%= user.email %></span>
             <% end %>
           </td>
-          <td class="govuk-table__cell text-right" scope="row">
+          <td class="govuk-table__cell text-right">
             <% if user.totp_enabled? %>
               <%= link_to({ controller: "users/two_factor_authentication", action: "edit", id: user },
                           class: "govuk-button govuk-button--secondary") do %>

--- a/app/views/super_admin/organisations/index.html.erb
+++ b/app/views/super_admin/organisations/index.html.erb
@@ -29,34 +29,34 @@
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header govuk-!-width-one-half"><%= sort_link "name" %></th>
-      <th class="govuk-table__header"><%= sort_link "created_at", "Created on" %></th>
-      <th class="govuk-table__header govuk-table__header"><%= sort_link "mous.created_at", "MOU Signed" %></th>
-      <th class="govuk-table__header govuk-table__header--numeric"><%= sort_link "locations_count", "Locations" %></th>
-      <th class="govuk-table__header govuk-table__header--numeric"><%= sort_link "ips_count", "IPs" %></th>
-      <th class="govuk-table__header"><%= sort_link "certificates_count", "Uses EAP-TLS" %></th>
+      <th class="govuk-table__header govuk-!-width-one-half" scope="row"><%= sort_link "name" %></th>
+      <th class="govuk-table__header"><%= sort_link "created_at", "Created on" scope="row" %></th>
+      <th class="govuk-table__header govuk-table__header" scope="row"><%= sort_link "mous.created_at", "MOU Signed" %></th>
+      <th class="govuk-table__header govuk-table__header--numeric" scope="row"><%= sort_link "locations_count", "Locations" %></th>
+      <th class="govuk-table__header govuk-table__header--numeric" scope="row"><%= sort_link "ips_count", "IPs" %></th>
+      <th class="govuk-table__header" scope="row"><%= sort_link "certificates_count", "Uses EAP-TLS" %></th>
     </tr>
   </thead>
   <tbody class="govuk-table__body" aria-live="polite">
     <% @organisations.each do |organisation| %>
       <tr class="govuk-table__row result-row">
-        <td class="govuk-table__cell govuk-!-width-one-half" scope="row">
+        <td class="govuk-table__cell govuk-!-width-one-half">
           <%= link_to organisation.name, super_admin_organisation_path(organisation), class: "govuk-link filter-by" %>
         </td>
-        <td class="govuk-table__cell" scope="row">
+        <td class="govuk-table__cell">
           <%= organisation.created_at.strftime("%e %b %Y") %>
         </td>
-        <td class="govuk-table__cell govuk-table__cell" scope="row">
+        <td class="govuk-table__cell govuk-table__cell">
           <% if organisation.latest_mou_created_at.present? %>
             <%= organisation.latest_mou_created_at.strftime("%e %b %Y") %>
           <% else %>
             -
           <% end %>
         </td>
-        <td class="govuk-table__cell govuk-table__cell--numeric" scope="row">
+        <td class="govuk-table__cell govuk-table__cell--numeric">
           <%= organisation.locations_count %>
         </td>
-        <td class="govuk-table__cell govuk-table__cell--numeric" scope="row">
+        <td class="govuk-table__cell govuk-table__cell--numeric">
           <%= organisation.ips_count %>
         </td>
         <td class="govuk-table__cell govuk-table__cell">

--- a/app/views/super_admin/organisations/index.html.erb
+++ b/app/views/super_admin/organisations/index.html.erb
@@ -30,7 +30,7 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header govuk-!-width-one-half" scope="row"><%= sort_link "name" %></th>
-      <th class="govuk-table__header"><%= sort_link "created_at", "Created on" scope="row" %></th>
+      <th class="govuk-table__header"><%= sort_link "created_at", "Created on", scope="row" %></th>
       <th class="govuk-table__header govuk-table__header" scope="row"><%= sort_link "mous.created_at", "MOU Signed" %></th>
       <th class="govuk-table__header govuk-table__header--numeric" scope="row"><%= sort_link "locations_count", "Locations" %></th>
       <th class="govuk-table__header govuk-table__header--numeric" scope="row"><%= sort_link "ips_count", "IPs" %></th>


### PR DESCRIPTION
### What
Attributes have been used incorrectly.


### Why

This affects screen reader users, as the intended purpose, to mark cells in the 'Username' column as being table headers for the row, which would then inform screen reading software to announce both the row and column table headers to screen reader users whilst they navigate the table, is not being achieved, due to the invalid application of the attribute.

Link to JIRA card (if applicable):
[GW-1915](https://technologyprogramme.atlassian.net/browse/GW-1915)


[GW-1915]: https://technologyprogramme.atlassian.net/browse/GW-1915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ