### PR TITLE
Remove Devise rememberable

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,6 @@ class User < ApplicationRecord
          :database_authenticatable,
          :registerable,
          :recoverable,
-         :rememberable,
          :trackable,
          :timeoutable,
          :validatable,


### PR DESCRIPTION
The rememberable module in Devise allows users to stay signed in across browser sessions by setting a persistent remember_me cookie. This cookie securely stores a token linked to the user’s account, enabling automatic authentication when the user revisits the app, unless the cookie is manually cleared or expired.

We currently don't use this functionality and it can therefore be removed
