### PR TITLE
Use constants for membership permissions throughout the app

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -7,7 +7,7 @@ class MembershipsController < ApplicationController
   def edit
     @permission_level_data = [
       OpenStruct.new(
-        value: "administrator",
+        value: Membership::Permissions::ADMINISTRATOR,
         text: "Administrator",
         hint: <<~HINT.html_safe,
           <span>View locations and IPs, team members, and logs</span><br>
@@ -17,7 +17,7 @@ class MembershipsController < ApplicationController
         HINT
       ),
       OpenStruct.new(
-        value: "manage_locations",
+        value: Membership::Permissions::MANAGE_LOCATIONS,
         text: "Manage Locations",
         hint: <<~HINT.html_safe,
           <span>View locations and IPs, team members, and logs</span><br>
@@ -27,7 +27,7 @@ class MembershipsController < ApplicationController
         HINT
       ),
       OpenStruct.new(
-        value: "view_only",
+        value: Membership::Permissions::VIEW_ONLY,
         text: "View only",
         hint: <<~HINT.html_safe,
           <span>View locations and IPs, team members, and logs</span><br>
@@ -41,10 +41,8 @@ class MembershipsController < ApplicationController
   def update
     permission_level = params.permit(:permission_level).fetch(:permission_level)
 
-    @membership.update!(
-      can_manage_team: permission_level == "administrator",
-      can_manage_locations: %w[administrator manage_locations].include?(permission_level),
-    )
+    @membership.permission_level = permission_level
+    @membership.save!
     flash[:notice] = "Permissions updated"
     redirect_to memberships_path
   end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -33,13 +33,8 @@ private
 
   def add_user_to_organisation(organisation)
     membership = invited_user.memberships.find_or_create_by!(invited_by_id: current_user.id, organisation:)
-
-    permission_level = params[:permission_level]
-    membership.update!(
-      can_manage_team: permission_level == "administrator",
-      can_manage_locations: %w[administrator manage_locations].include?(permission_level),
-    )
-
+    membership.permission_level = params[:permission_level]
+    membership.save!
     send_invite_email(membership) if user_has_confirmed_account?
   end
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,4 +1,10 @@
 class Membership < ApplicationRecord
+  module Permissions
+    ADMINISTRATOR = "administrator".freeze
+    MANAGE_LOCATIONS = "manage_locations".freeze
+    VIEW_ONLY = "view_only".freeze
+  end
+
   belongs_to :organisation
   belongs_to :user
   before_create :set_invitation_token
@@ -36,14 +42,14 @@ class Membership < ApplicationRecord
   end
 
   def permission_level=(value)
-    self.can_manage_locations = %w[administrator manage_locations].include?(value)
-    self.can_manage_team = value == "administrator"
+    self.can_manage_locations = [Permissions::ADMINISTRATOR, Permissions::MANAGE_LOCATIONS].include?(value)
+    self.can_manage_team = value == Permissions::ADMINISTRATOR
   end
 
   def permission_level
-    return "administrator" if administrator?
-    return "manage_locations" if manage_locations?
+    return Permissions::ADMINISTRATOR if administrator?
+    return Permissions::MANAGE_LOCATIONS if manage_locations?
 
-    "view_only"
+    Permissions::VIEW_ONLY
   end
 end

--- a/app/views/ips/_confirm_rotate_radius_key.html.erb
+++ b/app/views/ips/_confirm_rotate_radius_key.html.erb
@@ -18,6 +18,7 @@
     <%= button_to "Yes, rotate this RADIUS key", location_path(@key_to_rotate),
                   method: :patch, class: "govuk-button red-button" %>
                   <span class="govuk-visually-hidden">
-                  for <%= @key_to_rotate.address %>
+                    for <%= @key_to_rotate.address %>
+                  </span>
   </div>
 </div>

--- a/app/views/users/invitations/invite_second_admin.html.erb
+++ b/app/views/users/invitations/invite_second_admin.html.erb
@@ -26,7 +26,7 @@
       <h1 class="govuk-heading-l">Invite a team member</h1>
       <div class="govuk-grid-column-full govuk-!-padding-left-0">
         <%= f.govuk_email_field :email, label: { text: "Email address of team member" } %>
-        <%= f.hidden_field :permission_level, value: "administrator" %>
+        <%= f.hidden_field :permission_level, value: Membership::Permissions::ADMINISTRATOR %>
         <%= f.hidden_field :source, value: "invite_admin" %>
         <%= f.govuk_submit "Invite as an admin" %>
 

--- a/app/views/users/invitations/new.html.erb
+++ b/app/views/users/invitations/new.html.erb
@@ -26,7 +26,7 @@
             <div class="govuk-radios__item">
               <%= radio_button_tag(
                     :permission_level,
-                    "administrator",
+                    Membership::Permissions::ADMINISTRATOR,
                     false,
                     class: "govuk-radios__input",
                     "aria-described-by" => "permission_level_administrator_hint",
@@ -45,7 +45,7 @@
             <div class="govuk-radios__item">
               <%= radio_button_tag(
                     :permission_level,
-                    "manage_locations",
+                    Membership::Permissions::MANAGE_LOCATIONS,
                     false,
                     class: "govuk-radios__input",
                     "aria-described-by" => "permission_level_manage_locations_hint",
@@ -64,7 +64,7 @@
             <div class="govuk-radios__item">
               <%= radio_button_tag(
                     :permission_level,
-                    "view_only",
+                    Membership::Permissions::VIEW_ONLY,
                     false,
                     class: "govuk-radios__input",
                     "aria-described-by" => "permission_level_view_only_hint",

--- a/spec/features/support/sign_up_helpers.rb
+++ b/spec/features/support/sign_up_helpers.rb
@@ -12,7 +12,6 @@ def update_user_details(
   service_email: "admin@gov.uk",
   organisation_name: "Org 1"
 )
-
   visit Services.notify_gateway.last_confirmation_url
   select organisation_name, from: "Organisation name"
 


### PR DESCRIPTION
- Replaced hardcoded permission strings with constants defined in `Membership::Permissions` to improve code maintainability and consistency.
- Centralised all permission-related values, minimising the risk of typos and ensuring consistency across the codebase.

This change enhances readability, reduces duplication, and makes the permission system easier to modify and debug.

