### PR TITLE
Ensure that error pages render the correct error page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,6 +49,7 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_user_with_no_organisation
+    return if current_user.nil?
     return if current_user.is_super_admin? && current_organisation.present?
 
     if current_user.is_super_admin? && current_organisation.nil?


### PR DESCRIPTION
When entering an incorrect route in the admin portal, it returns a 500 error code with a message: 

```
500 Internal Server Error
If you are the administrator of this website, then please read this web application's log file and/or the web server's log file to find out what went wrong. 
```

This is an incorrect message and should instead be a message saying that the page does not exist with a 404 error code

Link to JIRA card (if applicable):
https://technologyprogramme.atlassian.net/browse/GW-2100
