### PR TITLE
Clean up unconfirmed users that have been created more than 2 weeks ago

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,8 @@ class User < ApplicationRecord
     order(build_order_query)
   }
 
+  scope :unconfirmed, -> { where(confirmed_at: nil) }
+
   def password_present?
     !password.nil?
   end

--- a/lib/tasks/delete_inactive_unconfirmed.rake
+++ b/lib/tasks/delete_inactive_unconfirmed.rake
@@ -1,0 +1,6 @@
+namespace :cleanup do
+  desc "Clean up inactive unconfirmed users"
+  task unconfirmed: :environment do
+    UseCases::DeleteInactiveUnconfirmed.execute(2.weeks)
+  end
+end

--- a/lib/use_cases/delete_inactive_unconfirmed.rb
+++ b/lib/use_cases/delete_inactive_unconfirmed.rb
@@ -1,0 +1,7 @@
+module UseCases
+  class DeleteInactiveUnconfirmed
+    def self.execute(inactive_period)
+      User.unconfirmed.where("created_at < ?", Time.zone.now - inactive_period).delete_all
+    end
+  end
+end

--- a/spec/use_cases/delete_inactive_unconfirmed_spec.rb
+++ b/spec/use_cases/delete_inactive_unconfirmed_spec.rb
@@ -1,0 +1,39 @@
+describe UseCases::DeleteInactiveUnconfirmed do
+  subject { UseCases::DeleteInactiveUnconfirmed }
+  let(:inactive_period) { 2.weeks }
+  describe "There are no unconfirmed users" do
+    before do
+      create(:user)
+    end
+    it "does not delete any users" do
+      expect { subject.execute(inactive_period) }.to_not change(User, :count)
+    end
+  end
+  describe "There is an inactive unconfirmed user who has been inactive for less than the specified period" do
+    before do
+      create(:user, :unconfirmed, created_at: 1.week.ago).id
+    end
+    it "does not delete any users" do
+      expect { subject.execute(inactive_period) }.to_not change(User, :count)
+    end
+  end
+  describe "There is an unconfirmed user who has been inactive for more than the specified period" do
+    before do
+      @inactive_user_id = create(:user, :unconfirmed, created_at: 3.weeks.ago).id
+    end
+    it "deletes the unconfirmed user" do
+      subject.execute(inactive_period)
+      expect(User.where(id: @inactive_user_id)).to_not exist
+    end
+  end
+  describe "There is a mix of unconfirmed and unconfirmed users" do
+    before do
+      create_list(:user, 2, :unconfirmed, created_at: 1.week.ago)
+      create_list(:user, 3, :unconfirmed, created_at: 3.weeks.ago)
+      create_list(:user, 7, created_at: 3.weeks.ago)
+    end
+    it "deletes the inactive unconfirmed users only" do
+      expect { subject.execute(inactive_period) }.to change(User, :count).by(-3)
+    end
+  end
+end


### PR DESCRIPTION
### What
Clean up unconfirmed users that have been created more than 2 weeks ago
These users have been sent an email with a link to confirm their account but have not accepted it

### Why
We want to keep the database free from clutter

Link to JIRA card (if applicable):
https://technologyprogramme.atlassian.net/browse/GW-2102