### PR TITLE
Update Github action runner

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Run lint


### PR DESCRIPTION
Ubuntu 20.04 is being deprecated and can now no longer run tasks
