### PR TITLE
GW-449: Optimise reading of sessions database

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,13 +35,13 @@ class ApplicationController < ActionController::Base
   end
 
   def current_organisation
-    if session[:organisation_id] && (current_user.confirmed_member_of?(session[:organisation_id].to_i) || super_admin?)
-      Organisation.find(session[:organisation_id])
-    elsif user_signed_in?
-      current_user.confirmed_organisations.first
-    end
+    @current_organisation ||= if session[:organisation_id] && (current_user.confirmed_member_of?(session[:organisation_id].to_i) || super_admin?)
+                                Organisation.find(session[:organisation_id])
+                              elsif user_signed_in?
+                                current_user.confirmed_organisations.first
+                              end
   rescue ActiveRecord::RecordNotFound
-    current_user.confirmed_organisations.first
+    @current_organisation ||= current_user.confirmed_organisations.first
   end
 
   def super_admin?

--- a/app/controllers/nominations_controller.rb
+++ b/app/controllers/nominations_controller.rb
@@ -5,12 +5,12 @@ class NominationsController < ApplicationController
 
   def create
     mou_params = params.require(:nomination).permit(:name, :email)
+    old_nomination = current_organisation.nomination
 
     @nomination = Nomination.new(mou_params.merge(nominated_by: current_user.name,
                                                   token: generate_token,
                                                   organisation: current_organisation))
     if @nomination.valid?
-      old_nomination = current_organisation.nomination
       old_nomination&.destroy!
       @nomination.save!
       send_nomination_email(@nomination.name,

--- a/app/views/logs/index.html.erb
+++ b/app/views/logs/index.html.erb
@@ -53,6 +53,7 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
+      <% is_current_organisation_cba_enabled = current_organisation&.cba_enabled? %>
       <% logs.each do |log| %>
         <tr class="govuk-table__row">
           <% unless log_search_form.username %>
@@ -62,7 +63,7 @@
               <% end %>
             </td>
           <% end %>
-          <% if log_search_form.ip && current_organisation&.cba_enabled? %>
+          <% if log_search_form.ip && is_current_organisation_cba_enabled %>
             <td class="govuk-table__cell"><%= log.eap_tls? ? "EAP-TLS" : "MSCHAP" %></td>
           <% end %>
           <td class="govuk-table__cell"><%= log.ap %></td>


### PR DESCRIPTION
### What

ApplicationController's `current_organisation` method is getting called inside the loop which results in repeated  queries and slowing down the page load.

### Why

To optimise the log search/filters, 'current_organisation` method needs to be memoized. 
It is good candidate for  memoization as it is being used in different pages of the application.

## Optimisation Result

### Search for location(development with seed data): "Momentum Centre, London"

<img width="719" alt="Screenshot 2025-03-20 at 18 12 25" src="https://github.com/user-attachments/assets/cb1e8e9c-2a13-48b1-bda5-c00fb89927c0" />


### Before:

![Screenshot 2025-03-20 at 18 13 18](https://github.com/user-attachments/assets/a3fc66b2-feaa-41e1-8291-b70d1c14e6b6)


### After:

![Screenshot 2025-03-20 at 18 13 50](https://github.com/user-attachments/assets/9108825d-1163-4950-ba03-a0b28ebf29f4)




Link to JIRA card (if applicable):
[GW-449](https://technologyprogramme.atlassian.net/browse/GW-449)
