### PR TITLE
GW-2156: Configure bullet gem and fix N+1 issues for organisation list and show pages

### DIFF
--- a/app/controllers/super_admin/organisations_controller.rb
+++ b/app/controllers/super_admin/organisations_controller.rb
@@ -3,7 +3,7 @@ class SuperAdmin::OrganisationsController < SuperAdminController
   before_action :set_organisation, only: %i[show destroy toggle_cba_feature]
 
   def index
-    @organisations = Organisation.sortable_with_child_counts(sort_column, sort_direction)
+    @organisations = Organisation.includes([:certificates]).sortable_with_child_counts(sort_column, sort_direction)
     @location_count = Location.count
     respond_to do |format|
       format.html
@@ -35,7 +35,7 @@ class SuperAdmin::OrganisationsController < SuperAdminController
 private
 
   def set_organisation
-    @organisation = Organisation.find(params[:id])
+    @organisation = Organisation.includes([locations: :ips]).find(params[:id])
   end
 
   def sortable_columns

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,9 +4,15 @@ require_relative "../../lib/gateways/development_notify_gateway"
 Rails.application.configure do
   config.notify_gateway = Gateways::DevelopmentNotifyGateway
   config.hosts.clear
-  Bullet.enable = true
+  Bullet.enable                      = true
+  Bullet.alert                       = true
+  Bullet.bullet_logger               = true
+  Bullet.console                     = true
+  Bullet.rails_logger                = true
+  Bullet.add_footer                  = true
   Bullet.unused_eager_loading_enable = true
   Bullet.n_plus_one_query_enable     = true
+  Bullet.counter_cache_enable = true
 
   config.web_console.permissions = %w[172.0.0.0/8 192.168.0.0/16 10.0.0.0/8]
 


### PR DESCRIPTION
### What

Configure bullet gem for alerts and logs for development environment:  https://github.com/flyerhzm/bullet?tab=readme-ov-file#configuration

### Why

- Optimise performance for Organisation list and show pages
- Show popup if N+1 issue exists (only in `development` environment)
- <img width="809" alt="Screenshot 2025-03-24 at 12 20 16" src="https://github.com/user-attachments/assets/90711f5c-9fda-4963-9400-d9adaad830bf" />

Link to JIRA card (if applicable):
[GW-2156](https://technologyprogramme.atlassian.net/browse/GW-2156)
