### PR TITLE
GW-449-improve-query-performance-reading-sessions 

### DIFF
--- a/lib/gateways/sessions.rb
+++ b/lib/gateways/sessions.rb
@@ -1,6 +1,7 @@
 module Gateways
   class Sessions
     MAXIMUM_RESULTS_COUNT = 500
+    SESSION_SELECT_ATTRIBUTES = %i[id start username siteIP success ap mac task_id].freeze
 
     def self.search(username: nil, ips: nil, success: nil, authentication_method: nil)
       new.search(username:, ips:, success:, authentication_method:)
@@ -8,8 +9,9 @@ module Gateways
 
     def search(username: nil, ips: nil, success: nil, authentication_method: nil)
       results = Session
+      .select(SESSION_SELECT_ATTRIBUTES)
       .where("start >= ?", 2.weeks.ago)
-      .order(start: :desc)
+      .order(id: :desc)
       .limit(MAXIMUM_RESULTS_COUNT)
 
       results = results.where(username:) unless username.nil?

--- a/spec/gateways/sessions_spec.rb
+++ b/spec/gateways/sessions_spec.rb
@@ -13,8 +13,8 @@ describe Gateways::Sessions do
     let!(:session_list) do
       [
         create(:session, start: two_days_ago, username:, ap: "ap3"),
-        create(:session, start: today_date, username:, ap: "ap1"),
         create(:session, start: yesterday, username:, ap: "ap2"),
+        create(:session, start: today_date, username:, ap: "ap1"),
       ]
     end
 


### PR DESCRIPTION
### What
Optimise query performance while filtering logs

### Why
- Load only required columns
- Ordering by `id(bigint)` is more efficient than ordering by `start(timestamp)`

> [!IMPORTANT]  
> TODO: Discuss if we should use `id` instead of `start` for ordering


### BENCHMARK TEST (700000 Session records in development environment)

```sql
SELECT `sessions`.* 
FROM `sessions` 
WHERE (start >= '2025-03-10 17:11:06.118846') 
ORDER BY `sessions`.`start` DESC;

-- Results
700000 rows in set (1.27 sec)
700000 rows in set (1.06 sec)
700000 rows in set (1.24 sec)
700000 rows in set (1.36 sec)
700000 rows in set (1.27 sec)
700000 rows in set (1.31 sec)
```
```sql
 SELECT `sessions`.`start`, `sessions`.`username`, `sessions`.`siteIP`, `sessions`.`success`, `sessions`.`ap`, `sessions`.`mac`, `sessions`.`task_id` 
FROM `sessions` 
WHERE (start >= '2025-03-10 17:17:49.247730') 
ORDER BY `sessions`.`start` DESC
700000 rows in set (1.12 sec)
700000 rows in set (0.91 sec)
700000 rows in set (0.73 sec)
700000 rows in set (0.89 sec)
700000 rows in set (1.01 sec)
700000 rows in set (0.76 sec)
```


```sql
SELECT `sessions`.`start`, `sessions`.`username`, `sessions`.`siteIP`, `sessions`.`success`, `sessions`.`ap`, `sessions`.`mac`, `sessions`.`task_id` 
FROM `sessions` 
WHERE (start >= '2025-03-10 17:17:49.247730') 
ORDER BY `sessions`.`id` DESC;

-- Results
700000 rows in set (0.47 sec)
700000 rows in set (0.44 sec)
700000 rows in set (0.45 sec)
700000 rows in set (0.41 sec)
700000 rows in set (0.43 sec)
700000 rows in set (0.46 sec)
```

Conclusion: Query time reduces by more then half when ordered by `id` on selected columns

```sql
-- INDEX information
SHOW KEYS FROM sessions;

+----------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+------------+
| Table    | Non_unique | Key_name                | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment | Visible | Expression |
+----------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+------------+
| sessions |          0 | PRIMARY                 |            1 | id          | A         |      620234 |     NULL |   NULL |      | BTREE      |         |               | YES     | NULL       |
| sessions |          1 | siteIP                  |            1 | siteIP      | A         |           1 |     NULL |   NULL | YES  | BTREE      |         |               | YES     | NULL       |
| sessions |          1 | siteIP                  |            2 | username    | A         |           1 |     NULL |   NULL | YES  | BTREE      |         |               | YES     | NULL       |
| sessions |          1 | sessions_username       |            1 | username    | A         |           1 |     NULL |   NULL | YES  | BTREE      |         |               | YES     | NULL       |
| sessions |          1 | sessions_start_username |            1 | start       | A         |           1 |     NULL |   NULL | YES  | BTREE      |         |               | YES     | NULL       |
| sessions |          1 | sessions_start_username |            2 | username    | A         |           1 |     NULL |   NULL | YES  | BTREE      |         |               | YES     | NULL       |
+----------+------------+-------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+---------+------------+
```


Link to JIRA card (if applicable):
[GW-449](https://technologyprogramme.atlassian.net/browse/GW-449)
