### PR TITLE
Set invitation token on memberships if set to NULL

### DIFF
--- a/db/migrate/20250423141522_set_membership_invitation_token.rb
+++ b/db/migrate/20250423141522_set_membership_invitation_token.rb
@@ -1,0 +1,14 @@
+class SetMembershipInvitationToken < ActiveRecord::Migration[7.0]
+  sql = <<~SQL
+    Select id as membership_id
+      from memberships
+        where invitation_token IS NULL
+  SQL
+
+  result_list = ActiveRecord::Base.connection.exec_query(sql)
+  result_list.each do |result|
+    invitation_token = Devise.friendly_token[0, 20]
+    sql = "update memberships set invitation_token = \"#{invitation_token}\" where id=#{result['membership_id']}"
+    ActiveRecord::Base.connection.exec_query(sql)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_13_112311) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_23_141522) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false


### PR DESCRIPTION
This is usually set in the before_create method in the model, but in the database there are a number that are NULL. This interferes with some code that expects this to be set.

This PR adds a migration that sets the invitation code to a random 20 character string

https://technologyprogramme.atlassian.net/browse/GW-2221
