### PR TITLE
GW-2231: Fix template error

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -52,7 +52,7 @@ class Users::InvitationsController < ApplicationController
   end
 
   def invite_second_admin
-    @form = InvitationForm.new(inviter: current_user, organisation: current_organisation)
+    @invitation_form = InvitationForm.new(inviter: current_user, organisation: current_organisation)
   end
 
 private

--- a/app/views/users/invitations/invite_second_admin.html.erb
+++ b/app/views/users/invitations/invite_second_admin.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "Invite a team member to be an administrator" %>
 
-<%= form_with model: @form, url: users_invitation_path do |f| %>
+<%= form_with model: @invitation_form, url: users_invitation_path do |f| %>
 
   <%= f.govuk_error_summary %>
 


### PR DESCRIPTION
### What

Fix `ActionView::Template::Error` for `Users::InvitationsController#create` action

<img width="520" alt="Screenshot 2025-04-29 at 16 36 43" src="https://github.com/user-attachments/assets/8ab80e9f-1538-48da-82b9-4bfa486a2d1c" />

Sentry: https://govwifi.sentry.io/issues/6560231065/?environment=production&project=1259357&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=1

WHY

This error occurred because on form variable name inconsistency in 
`app/controllers/users/invitations_controller.rb` > `create`

https://github.com/GovWifi/govwifi-admin/blob/fix-template-error/app/controllers/users/invitations_controller.rb#L12-L21


Link to JIRA card (if applicable):
[GW-2231](https://technologyprogramme.atlassian.net/browse/GW-2231)
