### PR TITLE
reset smoke test users

### DIFF
--- a/lib/tasks/reset_smoke_test_users.rake
+++ b/lib/tasks/reset_smoke_test_users.rake
@@ -1,0 +1,24 @@
+namespace :reset do
+  desc "Reset smoke test users to the passwords stored in AWS"
+  task smoke_test_users: :environment do
+    users = {
+      ENV["GW_USER"] => ENV["GW_PASS"],
+      ENV["GW_SUPER_ADMIN_USER"] => ENV["GW_SUPER_ADMIN_PASS"],
+    }
+
+    puts "Running password reset in: #{Rails.env}"
+
+    results = UseCases::ResetSmokeTestUsers.new(users).execute
+
+    results.each do |result|
+      case result[:status]
+      when :success
+        puts "Reset password for #{result[:email]}"
+      when :not_found
+        puts "User not found for #{result[:email]}"
+      when :error
+        puts "Failed to reset password for #{result[:email]}: #{result[:message]}"
+      end
+    end
+  end
+end

--- a/lib/use_cases/reset_smoke_test_users.rb
+++ b/lib/use_cases/reset_smoke_test_users.rb
@@ -1,0 +1,27 @@
+module UseCases
+  class ResetSmokeTestUsers
+    def initialize(user_credentials)
+      @user_credentials = user_credentials
+    end
+
+    def execute
+      @user_credentials.map do |email, password|
+        user = User.find_by(email: email)
+        if user.nil?
+          { email: email, status: :not_found }
+        else
+          begin
+            user.update!(
+              password: password,
+              password_confirmation: password,
+              confirmed_at: user.created_at,
+            )
+            { email: email, status: :success }
+          rescue StandardError => e
+            { email: email, status: :error, message: e.message }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/use_cases/reset_smoke_test_users_spec.rb
+++ b/spec/use_cases/reset_smoke_test_users_spec.rb
@@ -1,0 +1,52 @@
+describe UseCases::ResetSmokeTestUsers do
+  subject { UseCases::ResetSmokeTestUsers }
+  describe "reset smoke test users" do
+    let(:existing_user_email) { "user@gov.uk" }
+    let(:missing_user_email)  { "missing_user@gov.uk" }
+    let(:old_password)        { "Oldpassword1!" }
+    let(:new_password)        { "Newpassword1!" }
+
+    def create_user(email:, password:)
+      User.create!(
+        name: "Test User",
+        email: email,
+        password: password,
+        password_confirmation: password,
+        confirmed_at: Time.current,
+      )
+    end
+
+    context "when all users exist" do
+      it "resets passwords successfully" do
+        create_user(email: existing_user_email, password: old_password)
+
+        users = { existing_user_email => new_password }
+        result = described_class.new(users).execute
+
+        expect(result).to eq([
+          { email: existing_user_email, status: :success },
+        ])
+
+        user = User.find_by(email: existing_user_email)
+        expect(user.valid_password?(new_password)).to be true
+      end
+    end
+
+    context "when some users do not exist" do
+      it "returns not found for missing users" do
+        create_user(email: existing_user_email, password: old_password)
+
+        users = {
+          existing_user_email => new_password, missing_user_email => new_password
+        }
+
+        result = described_class.new(users).execute
+
+        expect(result).to contain_exactly(
+          { email: existing_user_email, status: :success },
+          { email: missing_user_email,  status: :not_found },
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What

Create a Rake task to reset the smoke test users details to the expected state, which we can run manually should the smoke tests fail.

### Why

The smoke tests can break if ran concurrently, which can leave the admin site in an inconsistent state and the smoke tests will fail with, invalid user/password, or unable to add / remove user. This happens because one of the steps in the smoke tests change the password of a user and back again.

Link to JIRA card (if applicable):
[[GW-xxxx](https://technologyprogramme.atlassian.net/browse/GW-xxxx)](https://technologyprogramme.atlassian.net/browse/GW-2195)
