### PR TITLE
Use the govuk table component for the email allowlist page

### DIFF
--- a/app/controllers/super_admin/allowlists/email_domains_controller.rb
+++ b/app/controllers/super_admin/allowlists/email_domains_controller.rb
@@ -3,6 +3,7 @@ class SuperAdmin::Allowlists::EmailDomainsController < SuperAdminController
 
   def index
     @authorised_email_domains = ordered_email_domains
+    @domain_to_remove = AuthorisedEmailDomain.find(params[:id]) if params.key?(:id)
   end
 
   def new

--- a/app/views/super_admin/allowlists/email_domains/_confirm_remove_email_domain.html.erb
+++ b/app/views/super_admin/allowlists/email_domains/_confirm_remove_email_domain.html.erb
@@ -3,6 +3,8 @@
     Are you sure you want to remove this email domain?
   </h2>
   <div class="govuk-error-summary__body">
-    <%= button_to "Yes, remove #{params[:domain_to_remove]} from the allow list", super_admin_allowlist_email_domain_path(params[:id]), method: :delete, class: "govuk-button red-button" %>
+    <%= govuk_button_to "Yes, remove #{@domain_to_remove.name} from the allow list",
+                        super_admin_allowlist_email_domain_path(@domain_to_remove),
+                        method: :delete, warning: true %>
   </div>
 </div>

--- a/app/views/super_admin/allowlists/email_domains/_table.html.erb
+++ b/app/views/super_admin/allowlists/email_domains/_table.html.erb
@@ -1,20 +1,20 @@
-<table class="govuk-table govuk-!-margin-bottom-8">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th class="govuk-table__header" scope="col">Email Domain</th>
-      <th class="govuk-table__header" scope="col">Date Added</th>
-      <th class="govuk-table__header" scope="col">Action</th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body" id="domains-table">
-    <% domains.each do |domain| %>
-      <tr class="govuk-table__row">
-        <th class="govuk-table__cell govuk-!-width-one-third" scope="row"><%= domain.name %></th>
-        <td class="govuk-table__cell"><%= domain.created_at.strftime("%e %b %Y") %></td>
-        <td class="govuk-table__cell text-right">
-          <%= link_to "Remove", super_admin_allowlist_email_domains_path(id: domain.id, domain_to_remove: domain.name), class: "govuk-link", aria: { label: "Remove #{domain.name} from the allow list" } %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= govuk_table do |table|
+  table.with_head do |head|
+    head.with_row do |row|
+      row.with_cell(text: 'Email Domain')
+      row.with_cell(text: 'Date Added')
+      row.with_cell(text: 'Action')
+    end
+  end
+  table.with_body do |body|
+    domains.each do |domain|
+      body.with_row do |row|
+        row.with_cell(text: domain.name)
+        row.with_cell(text: domain.created_at.strftime("%e %b %Y"))
+        row.with_cell(text: govuk_link_to("Remove",
+                                          super_admin_allowlist_email_domains_path(id: domain.id, domain_to_remove: domain.name),
+                                          visually_hidden_suffix: "#{domain.name} from the allow list"))
+      end
+    end
+  end
+end %>

--- a/app/views/super_admin/allowlists/email_domains/index.html.erb
+++ b/app/views/super_admin/allowlists/email_domains/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "Manage allowed email domains" %>
 
-<%= render "confirm_remove_email_domain" if params[:domain_to_remove] %>
+<%= render "confirm_remove_email_domain" if params[:id] %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-quarter">


### PR DESCRIPTION
Use the govuk table component for the email allowlist page

This ensures that the page is more compatible with the design system

https://technologyprogramme.atlassian.net/browse/GW-2259
