### PR TITLE
replace alphagov org with govwifi in docs urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ N.B. The GovWifi [terraform repository][terraform-repo] contains information on 
 ## Table of Contents
 
 - [GovWifi admin application](#govwifi-admin-application)
+- [TEST](#test)
   - [Table of Contents](#table-of-contents)
   - [Overview](#overview)
   - [Developing](#developing)
@@ -118,5 +119,5 @@ This codebase is released under [the MIT License][mit].
 [dev-docs]: https://govwifi-dev-docs.cloudapps.digital
 [notify]: https://www.notifications.service.gov.uk
 [zendesk]: https://govuk.zendesk.com/hc/en-us
-[terraform-repo]: https://github.com/alphagov/govwifi-terraform
+[terraform-repo]: https://github.com/GovWifi/govwifi-terraform
 [prod-deploy-pipeline]: https://cd.gds-reliability.engineering/teams/govwifi/pipelines/admin-deploy?groups=Production


### PR DESCRIPTION
### What

Update our docs to reflect changes in GDS repos
Remove legacy links

### Why

We must keep our docs up to date and accurate

Link to JIRA card (if applicable):
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251/backlog?assignee=5b2a20739ba6d02662e2fc0b&selectedIssue=GW-2341