### PR TITLE
feature: GW-2319 Add ruby updater

### DIFF
--- a/.github/workflows/ruby_updater.yml
+++ b/.github/workflows/ruby_updater.yml
@@ -1,0 +1,22 @@
+name: Upgrade Ruby
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "20 0 15 * 0" # Runs monthly (in the middle to avoid any date clashes)
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  upgrade-ruby:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: run updater
+        uses: govwifi/shared-actions-workflows/.github/actions/ruby-updater@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          main-branch: master


### PR DESCRIPTION
### What

Add Ruby Updater workflow

### Why

To automate the updating of Ruby

Link to JIRA card (if applicable):
[GW-2319](https://technologyprogramme.atlassian.net/browse/GW-2319)
