### PR TITLE
GW-2319 new ruby updater workflow

### DIFF
--- a/.github/workflows/ruby-updater.yml
+++ b/.github/workflows/ruby-updater.yml
@@ -63,7 +63,7 @@ jobs:
   labeler:
     ## Auto add labels to the PR
     runs-on: ubuntu-latest
-    needs: [check-ruby-setup]
+    needs: [check-ruby-setup, upgrade-ruby]
     steps:
       - name: add labels
         env:


### PR DESCRIPTION
### What

Add dependency on previous job

### Why

Else the labeler runs in the wrong order.

Link to JIRA card (if applicable):
[GW-2319](https://technologyprogramme.atlassian.net/browse/GW-2319)
