### PR TITLE
Revert "remove robots.txt to see if it fixes smoketests in prod"

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Reverts GovWifi/govwifi-admin#2505

Restores the robots.txt we removed when we though it was causing issues, which it is not.