### PR TITLE
Fix brace-expansion DoS vulnerability (Dependabot #224)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -125,9 +125,9 @@ balanced-match@^2.0.0:
   integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
 
 brace-expansion@^1.1.7:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.13.tgz#d37875c01dc9eff988dd49d112a57cb67b54efe6"
-  integrity sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
## Fix for [Dependabot 2240](https://github.com/GovWifi/govwifi-admin/security/dependabot/224)

### What

- Bumped transitive dev dependency `brace-expansion` from `1.1.13` to `1.1.18` in `yarn.lock` (stylelint → file-entry-cache → flat-cache → rimraf → glob → minimatch → brace-expansion)
- No `package.json` change needed — `minimatch` already declares `brace-expansion@^1.1.7`, and `1.1.18` (latest 1.x) satisfies that range, so this is a lockfile-only, non-breaking patch bump
- Verified the fix with `yarn audit` (brace-expansion no longer listed) and by running the full Ruby test suite plus the `stylelint`/`prettier` lint targets via `docker compose` — 1191 examples, 0 failures; lints clean

### Why

- CVE-2026-13149 / GHSA-3jxr-9vmj-r5cp: the `expand()` function in brace-expansion has exponential-time (O(2^n)) behaviour on consecutive non-expanding `{}` groups, so a small crafted input (around 90 bytes) can hang the calling thread for minutes
- brace-expansion here is a dev-only transitive dependency of stylelint (used for SCSS linting), not part of the runtime app, so exposure is limited to the local/CI lint step rather than the deployed application, but it still needs patching to close the alert
- This is the only change needed to clear alert #224; no other dependency upgrades were required (other issues currently reported by `yarn audit`/Dependabot — fast-uri #228, postcss #225, activestorage #227 — are separate, already-tracked alerts out of scope for this PR)

### Link to JIRA card (if applicable):

- [GW-2883](https://technologyprogramme.atlassian.net/browse/GW-2883)