### PR TITLE
How many Organisations have no physical addresses associated with their IP address?

### DIFF
--- a/lib/tasks/publish_orgs_with_no_physical_address_for_ip_count.rake
+++ b/lib/tasks/publish_orgs_with_no_physical_address_for_ip_count.rake
@@ -1,0 +1,11 @@
+require "logger"
+
+namespace :metrics do
+  desc "Publish orgs with no physical address for IP count to S3 and post to metrics API"
+  task publish_orgs_with_no_physical_address_for_ip_count: :environment do
+    logger = Logger.new($stdout)
+    logger.info("BEGIN: Publishing orgs with no physical address for IP count...")
+    UseCases::Administrator::PublishOrgsWithNoPhysicalAddressForIpCount.new.publish
+    logger.info("END: Publishing orgs with no physical address for IP count")
+  end
+end

--- a/lib/use_cases/administrator/publish_orgs_with_no_physical_address_for_ip_count.rb
+++ b/lib/use_cases/administrator/publish_orgs_with_no_physical_address_for_ip_count.rb
@@ -1,0 +1,64 @@
+require "logger"
+
+module UseCases
+  module Administrator
+    class PublishOrgsWithNoPhysicalAddressForIpCount
+      METRIC_NAME = "account-health-orgs-with-no-physical-address-for-ip-count".freeze
+      S3_FOLDER = "account-health-orgs-with-no-physical-address-for-ip-count".freeze
+
+      def initialize(logger: Logger.new($stdout))
+        @logger = logger
+      end
+
+      def publish
+        send_to_s3
+        send_to_api
+      end
+
+    private
+
+      def today
+        @today ||= Time.zone.today
+      end
+
+      def metric
+        @metric ||= ::Location
+          .where("(postcode IS NULL OR postcode = '' OR LOWER(postcode) = 'unknown') AND (address IS NULL OR address = '' OR LOWER(address) = 'unknown')")
+          .count
+      end
+
+      def stats
+        {
+          metric_name: METRIC_NAME,
+          count: metric,
+          run_time: today,
+        }
+      end
+
+      def s3_key
+        "#{S3_FOLDER}/#{METRIC_NAME}-#{today.iso8601}"
+      end
+
+      def s3_payload
+        {
+          count: metric,
+          metric_name: METRIC_NAME,
+          period: "day",
+          date: today.iso8601,
+        }
+      end
+
+      def send_to_s3
+        @logger.info("BEGIN: Writing to S3 bucket...")
+        Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).write("#{s3_payload.to_json}\n")
+        @logger.info("END: Writing to S3 bucket - (Orgs with no physical address for IP count: #{metric})")
+      end
+
+      def send_to_api
+        @logger.info("BEGIN: Posting to metrics API...")
+        UseCases::PerformancePlatform::MetricsApiPublisher.publish(stats)
+        @logger.info("END: Posting to metrics API - (Orgs with no physical address for IP count: #{metric})")
+      end
+    end
+  end
+end

--- a/lib/use_cases/administrator/publish_orgs_with_no_physical_address_for_ip_count.rb
+++ b/lib/use_cases/administrator/publish_orgs_with_no_physical_address_for_ip_count.rb
@@ -22,8 +22,10 @@ module UseCases
       end
 
       def metric
-        @metric ||= ::Location
-          .where("(postcode IS NULL OR postcode = '' OR LOWER(postcode) = 'unknown') AND (address IS NULL OR address = '' OR LOWER(address) = 'unknown')")
+        @metric ||= ::Organisation
+          .joins(:locations)
+          .where("(locations.postcode IS NULL OR locations.postcode = '' OR LOWER(locations.postcode) = 'unknown') AND (locations.address IS NULL OR locations.address = '' OR LOWER(locations.address) = 'unknown')")
+          .distinct
           .count
       end
 

--- a/spec/use_cases/administrator/publish_orgs_with_no_physical_address_for_ip_count_spec.rb
+++ b/spec/use_cases/administrator/publish_orgs_with_no_physical_address_for_ip_count_spec.rb
@@ -39,7 +39,7 @@ describe UseCases::Administrator::PublishOrgsWithNoPhysicalAddressForIpCount do
 
   context "when a location has empty postcode and nil address" do
     it "counts it" do
-      build(:location, postcode: "", address: nil).save(validate: false)
+      build(:location, postcode: "", address: nil).save!(validate: false)
 
       use_case.publish
 
@@ -90,7 +90,7 @@ describe UseCases::Administrator::PublishOrgsWithNoPhysicalAddressForIpCount do
   context "when multiple locations qualify" do
     it "aggregates the count across locations" do
       create(:location, postcode: "unknown", address: "unknown")
-      build(:location, postcode: "", address: "").save(validate: false)
+      build(:location, postcode: "", address: "").save!(validate: false)
       create(:location, postcode: "SW1A 1AA", address: "10 Downing Street")
 
       use_case.publish

--- a/spec/use_cases/administrator/publish_orgs_with_no_physical_address_for_ip_count_spec.rb
+++ b/spec/use_cases/administrator/publish_orgs_with_no_physical_address_for_ip_count_spec.rb
@@ -1,0 +1,132 @@
+describe UseCases::Administrator::PublishOrgsWithNoPhysicalAddressForIpCount do
+  subject(:use_case) { described_class.new }
+
+  let(:today) { Time.zone.local(2026, 7, 17) }
+  let(:s3_key) do
+    "account-health-orgs-with-no-physical-address-for-ip-count/account-health-orgs-with-no-physical-address-for-ip-count-2026-07-17"
+  end
+  let(:metrics_api_endpoint) { "https://metrics.test.example.com" }
+  let(:api_endpoint) { "#{metrics_api_endpoint}/v1/record" }
+
+  before do
+    stub_request(:post, api_endpoint).to_return(status: 200, body: "", headers: {})
+  end
+
+  around do |example|
+    original_endpoint = ENV["METRICS_API_ENDPOINT"]
+    original_token = ENV["METRICS_API_BEARER_TOKEN"]
+    ENV["METRICS_API_ENDPOINT"] = metrics_api_endpoint
+    ENV["METRICS_API_BEARER_TOKEN"] = "test-token"
+    Timecop.freeze(today) { example.run }
+    ENV["METRICS_API_ENDPOINT"] = original_endpoint
+    ENV["METRICS_API_BEARER_TOKEN"] = original_token
+  end
+
+  context "when a location has both postcode 'unknown' and address 'unknown'" do
+    it "counts it" do
+      create(:location, postcode: "unknown", address: "unknown")
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)).to eq(
+        "count" => 1,
+        "metric_name" => "account-health-orgs-with-no-physical-address-for-ip-count",
+        "period" => "day",
+        "date" => "2026-07-17",
+      )
+    end
+  end
+
+  context "when a location has empty postcode and nil address" do
+    it "counts it" do
+      build(:location, postcode: "", address: nil).save(validate: false)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(1)
+    end
+  end
+
+  context "when a location has case-insensitive 'UNKNOWN' values" do
+    it "counts it" do
+      create(:location, postcode: "UNKNOWN", address: "Unknown")
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(1)
+    end
+  end
+
+  context "when a location has a valid address and valid postcode" do
+    it "does not count it" do
+      create(:location, postcode: "SW1A 1AA", address: "10 Downing Street")
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  context "when a location has an unknown postcode but a valid address" do
+    it "does not count it" do
+      create(:location, postcode: "unknown", address: "10 Downing Street")
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  context "when a location has a valid postcode but an unknown address" do
+    it "does not count it" do
+      create(:location, postcode: "SW1A 1AA", address: "unknown")
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  context "when multiple locations qualify" do
+    it "aggregates the count across locations" do
+      create(:location, postcode: "unknown", address: "unknown")
+      build(:location, postcode: "", address: "").save(validate: false)
+      create(:location, postcode: "SW1A 1AA", address: "10 Downing Street")
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(2)
+    end
+  end
+
+  context "when no locations qualify" do
+    it "publishes a zero count rather than erroring" do
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  it "posts the count to the metrics api" do
+    create(:location, postcode: "unknown", address: "unknown")
+
+    use_case.publish
+
+    expect(a_request(:post, api_endpoint).with(
+             body: {
+               "name" => "account-health-orgs-with-no-physical-address-for-ip-count",
+               "value" => "1",
+               "datetime" => "2026-07-17T00:00:00Z",
+             }.to_json,
+           )).to have_been_made
+  end
+
+  context "when the metrics api request fails" do
+    it "does not raise an error" do
+      stub_request(:post, api_endpoint).to_timeout
+      create(:location, postcode: "unknown", address: "unknown")
+
+      expect { use_case.publish }.not_to raise_error
+    end
+  end
+end

--- a/spec/use_cases/administrator/publish_orgs_with_no_physical_address_for_ip_count_spec.rb
+++ b/spec/use_cases/administrator/publish_orgs_with_no_physical_address_for_ip_count_spec.rb
@@ -22,8 +22,8 @@ describe UseCases::Administrator::PublishOrgsWithNoPhysicalAddressForIpCount do
     ENV["METRICS_API_BEARER_TOKEN"] = original_token
   end
 
-  context "when a location has both postcode 'unknown' and address 'unknown'" do
-    it "counts it" do
+  context "when an organisation has a location with postcode 'unknown' and address 'unknown'" do
+    it "counts the organisation" do
       create(:location, postcode: "unknown", address: "unknown")
 
       use_case.publish
@@ -37,8 +37,32 @@ describe UseCases::Administrator::PublishOrgsWithNoPhysicalAddressForIpCount do
     end
   end
 
-  context "when a location has empty postcode and nil address" do
-    it "counts it" do
+  context "when an organisation has multiple locations with no physical address" do
+    it "counts the organisation only once" do
+      organisation = create(:organisation)
+      create(:location, organisation:, postcode: "unknown", address: "unknown")
+      build(:location, organisation:, postcode: "", address: nil).save!(validate: false)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(1)
+    end
+  end
+
+  context "when an organisation has one valid location and one location with no physical address" do
+    it "counts the organisation" do
+      organisation = create(:organisation)
+      create(:location, organisation:, postcode: "SW1A 1AA", address: "10 Downing Street")
+      create(:location, organisation:, postcode: "unknown", address: "unknown")
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(1)
+    end
+  end
+
+  context "when an organisation has empty postcode and nil address" do
+    it "counts the organisation" do
       build(:location, postcode: "", address: nil).save!(validate: false)
 
       use_case.publish
@@ -47,8 +71,8 @@ describe UseCases::Administrator::PublishOrgsWithNoPhysicalAddressForIpCount do
     end
   end
 
-  context "when a location has case-insensitive 'UNKNOWN' values" do
-    it "counts it" do
+  context "when an organisation has case-insensitive 'UNKNOWN' values" do
+    it "counts the organisation" do
       create(:location, postcode: "UNKNOWN", address: "Unknown")
 
       use_case.publish
@@ -57,8 +81,8 @@ describe UseCases::Administrator::PublishOrgsWithNoPhysicalAddressForIpCount do
     end
   end
 
-  context "when a location has a valid address and valid postcode" do
-    it "does not count it" do
+  context "when an organisation has only valid locations" do
+    it "does not count the organisation" do
       create(:location, postcode: "SW1A 1AA", address: "10 Downing Street")
 
       use_case.publish
@@ -67,8 +91,8 @@ describe UseCases::Administrator::PublishOrgsWithNoPhysicalAddressForIpCount do
     end
   end
 
-  context "when a location has an unknown postcode but a valid address" do
-    it "does not count it" do
+  context "when an organisation has an unknown postcode but a valid address" do
+    it "does not count the organisation" do
       create(:location, postcode: "unknown", address: "10 Downing Street")
 
       use_case.publish
@@ -77,8 +101,8 @@ describe UseCases::Administrator::PublishOrgsWithNoPhysicalAddressForIpCount do
     end
   end
 
-  context "when a location has a valid postcode but an unknown address" do
-    it "does not count it" do
+  context "when an organisation has a valid postcode but an unknown address" do
+    it "does not count the organisation" do
       create(:location, postcode: "SW1A 1AA", address: "unknown")
 
       use_case.publish
@@ -87,11 +111,32 @@ describe UseCases::Administrator::PublishOrgsWithNoPhysicalAddressForIpCount do
     end
   end
 
-  context "when multiple locations qualify" do
-    it "aggregates the count across locations" do
-      create(:location, postcode: "unknown", address: "unknown")
-      build(:location, postcode: "", address: "").save!(validate: false)
-      create(:location, postcode: "SW1A 1AA", address: "10 Downing Street")
+  context "when an organisation has no locations at all" do
+    it "does not count the organisation" do
+      create(:organisation)
+
+      use_case.publish
+
+      expect(JSON.parse(Gateways::S3.new(bucket: ENV.fetch("S3_METRICS_BUCKET"), key: s3_key).read)["count"]).to eq(0)
+    end
+  end
+
+  context "when multiple organisations have qualifying locations" do
+    it "aggregates the count across distinct organisations" do
+      org1 = create(:organisation)
+      org2 = create(:organisation)
+      org3 = create(:organisation)
+
+      # org1 has 2 incomplete locations (should count as 1)
+      create(:location, organisation: org1, postcode: "unknown", address: "unknown")
+      build(:location, organisation: org1, postcode: "", address: "").save!(validate: false)
+
+      # org2 has 1 incomplete and 1 valid location (should count as 1)
+      create(:location, organisation: org2, postcode: "unknown", address: "unknown")
+      create(:location, organisation: org2, postcode: "SW1A 1AA", address: "10 Downing Street")
+
+      # org3 has only valid locations (should not count)
+      create(:location, organisation: org3, postcode: "EC1A 1BB", address: "123 High Street")
 
       use_case.publish
 
@@ -99,7 +144,7 @@ describe UseCases::Administrator::PublishOrgsWithNoPhysicalAddressForIpCount do
     end
   end
 
-  context "when no locations qualify" do
+  context "when no organisations qualify" do
     it "publishes a zero count rather than erroring" do
       use_case.publish
 


### PR DESCRIPTION
## How many Organisations have no physical addresses associated with their IP address?

### What

- Added `UseCases::Administrator::PublishOrgsWithNoPhysicalAddressForIpCount` to count locations with missing or placeholder physical addresses.
- Created `metrics:publish_orgs_with_no_physical_address_for_ip_count` Rake task to upload results to S3 and POST to the Metrics API.
- Added comprehensive unit spec suite covering valid, invalid, placeholder, and failure scenarios.

### Why

- Enables account health monitoring for IP address locations that lack physical address details.
- Automates daily data collection for Tableau reporting and metrics dashboards.
- Helps identify non-compliant organisation locations requiring address updates.

### Link to JIRA card (if applicable):

- [GW-2752](https://technologyprogramme.atlassian.net/browse/GW-2752)